### PR TITLE
add key player toggle on UI

### DIFF
--- a/InazumaElevenSaveEditor/Welcome.Designer.cs
+++ b/InazumaElevenSaveEditor/Welcome.Designer.cs
@@ -99,6 +99,8 @@ namespace InazumaElevenSaveEditor
             this.label21 = new System.Windows.Forms.Label();
             this.levelNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.label15 = new System.Windows.Forms.Label();
+            this.keyPlayerLabel = new System.Windows.Forms.Label();
+            this.keyPlayerBox = new System.Windows.Forms.CheckBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.removeMiximaxButton = new System.Windows.Forms.Button();
@@ -501,6 +503,8 @@ namespace InazumaElevenSaveEditor
             this.tabPage1.Controls.Add(this.label21);
             this.tabPage1.Controls.Add(this.levelNumericUpDown);
             this.tabPage1.Controls.Add(this.label15);
+            this.tabPage1.Controls.Add(this.keyPlayerLabel);
+            this.tabPage1.Controls.Add(this.keyPlayerBox);
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
@@ -1066,6 +1070,26 @@ namespace InazumaElevenSaveEditor
             this.label15.Size = new System.Drawing.Size(21, 13);
             this.label15.TabIndex = 220;
             this.label15.Text = "TP";
+            // 
+            // keyPlayerLabel
+            // 
+            this.keyPlayerLabel.AutoSize = true;
+            this.keyPlayerLabel.Location = new System.Drawing.Point(221, 352);
+            this.keyPlayerLabel.Name = "keyPlayerLabel";
+            this.keyPlayerLabel.Size = new System.Drawing.Size(54, 13);
+            this.keyPlayerLabel.TabIndex = 220;
+            this.keyPlayerLabel.Text = "KeyPlayer";
+            // 
+            // keyPlayerBox
+            // 
+            this.keyPlayerBox.AutoSize = true;
+            this.keyPlayerBox.BackColor = System.Drawing.Color.White;
+            this.keyPlayerBox.Location = new System.Drawing.Point(281, 352);
+            this.keyPlayerBox.Name = "keyPlayerBox";
+            this.keyPlayerBox.Size = new System.Drawing.Size(15, 14);
+            this.keyPlayerBox.TabIndex = 223;
+            this.keyPlayerBox.UseVisualStyleBackColor = false;
+            this.keyPlayerBox.CheckedChanged += new System.EventHandler(this.KeyPlayerBox_CheckChanged);
             // 
             // tabPage2
             // 
@@ -2846,6 +2870,8 @@ namespace InazumaElevenSaveEditor
         public System.Windows.Forms.NumericUpDown moveNumericUpDown5;
         public System.Windows.Forms.Label moveLabel2;
         public System.Windows.Forms.Label moveLabel5;
+        public System.Windows.Forms.Label keyPlayerLabel;
+        public System.Windows.Forms.CheckBox keyPlayerBox;
         private System.Windows.Forms.TabPage tabPage4;
         private System.Windows.Forms.ToolStripMenuItem managePlayerTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem addToolStripMenuItem;

--- a/InazumaElevenSaveEditor/Welcome.Designer.cs
+++ b/InazumaElevenSaveEditor/Welcome.Designer.cs
@@ -1074,17 +1074,17 @@ namespace InazumaElevenSaveEditor
             // keyPlayerLabel
             // 
             this.keyPlayerLabel.AutoSize = true;
-            this.keyPlayerLabel.Location = new System.Drawing.Point(221, 352);
+            this.keyPlayerLabel.Location = new System.Drawing.Point(302, 12);
             this.keyPlayerLabel.Name = "keyPlayerLabel";
-            this.keyPlayerLabel.Size = new System.Drawing.Size(54, 13);
+            this.keyPlayerLabel.Size = new System.Drawing.Size(57, 13);
             this.keyPlayerLabel.TabIndex = 220;
-            this.keyPlayerLabel.Text = "KeyPlayer";
+            this.keyPlayerLabel.Text = "Key Player";
             // 
             // keyPlayerBox
             // 
             this.keyPlayerBox.AutoSize = true;
             this.keyPlayerBox.BackColor = System.Drawing.Color.White;
-            this.keyPlayerBox.Location = new System.Drawing.Point(281, 352);
+            this.keyPlayerBox.Location = new System.Drawing.Point(365, 11);
             this.keyPlayerBox.Name = "keyPlayerBox";
             this.keyPlayerBox.Size = new System.Drawing.Size(15, 14);
             this.keyPlayerBox.TabIndex = 223;

--- a/InazumaElevenSaveEditor/Welcome.Designer.cs
+++ b/InazumaElevenSaveEditor/Welcome.Designer.cs
@@ -1074,7 +1074,7 @@ namespace InazumaElevenSaveEditor
             // keyPlayerLabel
             // 
             this.keyPlayerLabel.AutoSize = true;
-            this.keyPlayerLabel.Location = new System.Drawing.Point(302, 12);
+            this.keyPlayerLabel.Location = new System.Drawing.Point(316, 12);
             this.keyPlayerLabel.Name = "keyPlayerLabel";
             this.keyPlayerLabel.Size = new System.Drawing.Size(57, 13);
             this.keyPlayerLabel.TabIndex = 220;
@@ -1084,7 +1084,7 @@ namespace InazumaElevenSaveEditor
             // 
             this.keyPlayerBox.AutoSize = true;
             this.keyPlayerBox.BackColor = System.Drawing.Color.White;
-            this.keyPlayerBox.Location = new System.Drawing.Point(365, 11);
+            this.keyPlayerBox.Location = new System.Drawing.Point(295, 12);
             this.keyPlayerBox.Name = "keyPlayerBox";
             this.keyPlayerBox.Size = new System.Drawing.Size(15, 14);
             this.keyPlayerBox.TabIndex = 223;

--- a/InazumaElevenSaveEditor/Welcome.cs
+++ b/InazumaElevenSaveEditor/Welcome.cs
@@ -552,6 +552,8 @@ namespace InazumaElevenSaveEditor
                 styleBox.Enabled = Save.Game.Code != "IEGO";
                 armedBox.Visible = Save.Game.Code != "IEGO";
                 label22.Visible = Save.Game.Code != "IEGO";
+                keyPlayerBox.Visible = Save.Game.Code == "IEGO";
+                keyPlayerLabel.Visible = Save.Game.Code == "IEGO";
                 saveToolStripMenuItem1.Enabled = true;
                 tabControl1.Enabled = false;
                 managePlayerTabToolStripMenuItem.Enabled = true;

--- a/InazumaElevenSaveEditor/Welcome.cs
+++ b/InazumaElevenSaveEditor/Welcome.cs
@@ -170,6 +170,9 @@ namespace InazumaElevenSaveEditor
                 investedNumericUpDown.Enabled = player.InvestedPoint.Sum() == 0;
             }
 
+            //print keyplayer
+            keyPlayerBox.Checked = player.IsKeyPlayer;
+
             // Print Figthing Spirit
             int avatarIndex = avatarNameBox.Items.Cast<Avatar>()
                            .Select((item, idx) => new { Item = item, Index = idx })
@@ -1518,5 +1521,16 @@ namespace InazumaElevenSaveEditor
             Player player = Save.Game.Reserve[SelectedPlayers[tabControl4.SelectedIndex]];
             player.TP = Convert.ToInt32(tpNumericUpDown.Value);
         }
+        private void KeyPlayerBox_CheckChanged(object sender, EventArgs e)
+        {
+            if (!keyPlayerBox.Focused) return;
+
+            Player player = Save.Game.Reserve[SelectedPlayers[tabControl4.SelectedIndex]];
+
+          
+
+            player.IsKeyPlayer = keyPlayerBox.Checked;
+        }
+
     }
 }

--- a/InazumaElevenSaveEditor/Welcome.resx
+++ b/InazumaElevenSaveEditor/Welcome.resx
@@ -126,6 +126,9 @@
   <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>272, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
add a toggle checkbox to allow user to freely change if player is key or not. ![image](https://github.com/user-attachments/assets/06b06881-7171-4364-9c4a-d463e03c990c)

There was a bug in previous versions that was fixed in last release where players would randomly become key, so this option would let users adjust their saves to correct key players without reverting to an old backup
![image](https://github.com/user-attachments/assets/94b22be8-e451-48d1-a885-1227670274f9)
